### PR TITLE
DBC22-4938: disable user, alerts and undo

### DIFF
--- a/src/frontend/app/components/shared/Alert.jsx
+++ b/src/frontend/app/components/shared/Alert.jsx
@@ -1,0 +1,80 @@
+// React
+import React, { useContext, useEffect, useState } from 'react';
+
+// External imports
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faCheckCircle, faCircleInfo } from '@fortawesome/pro-regular-svg-icons';
+
+// Internal imports
+import { AlertContext } from "../../contexts.js";
+
+// Styling
+import './Alert.scss';
+
+export default function Alert() {
+  /* Setup */
+  // Context
+  const { alertContext, setAlertContext } = useContext(AlertContext);
+  
+  // States
+  const [visible, setVisible] = useState(false);
+  const [renderedAlert, setRenderedAlert] = useState(alertContext);
+  const [seconds, setSeconds] = useState(5);
+
+  // Effects
+  useEffect(() => {
+    // Do not update on closing
+    if (alertContext) {
+      setVisible(true);
+      setRenderedAlert(alertContext);
+      setSeconds(5);
+
+    } else {
+      setVisible(false);
+    }
+  }, [alertContext]);
+
+  // Countdown effect
+  useEffect(() => {
+    if (seconds === 0) return;
+
+    const interval = setInterval(() => {
+      setSeconds(prev => prev - 1);
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [seconds]);
+
+  /* Main rendering function */
+  return renderedAlert && (
+    <div className={`alert fade-out ${!visible ? 'hidden' : ''}`}>
+      <div className="content">
+        <div className="content__text">
+          <FontAwesomeIcon icon={renderedAlert.icon === 'success' ? faCheckCircle : faCircleInfo} />
+          {renderedAlert.message}
+        </div>
+
+        {renderedAlert.undoHandler &&
+          <div className={'content__undo'}>
+            {seconds}s
+
+            <button
+              tabIndex={0}
+              onClick={() => {
+                renderedAlert.undoHandler();
+                setAlertContext(null);
+              }}
+              onKeyDown={(keyEvent) => {
+                if (['Enter', 'NumpadEnter'].includes(keyEvent.key)) {
+                  renderedAlert.undoHandler();
+                  setAlertContext(null);
+                }
+              }}>
+              Undo
+            </button>
+          </div>
+        }
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/app/components/shared/Alert.scss
+++ b/src/frontend/app/components/shared/Alert.scss
@@ -1,0 +1,88 @@
+@import "../../styles/variables.scss";
+
+.fade-out {
+  opacity: 1;
+  transition: opacity 0.5s ease-out;
+}
+
+.fade-out.hidden {
+  opacity: 0;
+}
+
+.alert {
+  position: fixed;
+  left: 50%;
+  bottom: 0;
+  transform: translate(-50%, -50%);
+  background-color: $Grey100;
+  padding: 0.5rem 0.75rem;
+  border-radius: 4px;
+  box-shadow: 0px 1.937px 4.358px 0px rgba(0, 0, 0, 0.13), 0px 0.363px 1.089px 0px rgba(0, 0, 0, 0.10);
+  z-index: 22;
+  text-wrap: nowrap;
+  color: white;
+  display: flex;
+  align-items: center;
+
+  animation: fade-in 0.3s;
+  @keyframes fade-in {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 100;
+    }
+  }
+
+  .alert-close-btn {
+    padding: 0;
+    font-size: 0.75rem;
+    width: 20px;
+    height: 20px;
+    border-radius: 10px;
+    margin: 0 0 0 1rem;
+
+    @media (max-width: 767px) {
+      top: 0.75rem;
+      right: 0.75rem;
+    }
+  }
+
+  .content {
+    display: flex;
+    align-items: center;
+
+    &__text {
+      margin: 0;
+      font-size: 16px;
+
+      svg {
+        margin-right: .5rem;
+      }
+
+      p {
+        font-size: 0.875rem;
+        color: white;
+        margin: 0;
+
+        &.feedback {
+          color: $Info;
+        }
+      }
+
+      a {
+        color: white;
+      }
+    }
+
+    &__undo {
+      margin-left: 1rem;
+
+      button {
+        margin-left: .5rem;
+        text-decoration: underline;
+        cursor: pointer;
+      }
+    }
+  }
+}

--- a/src/frontend/app/contexts.js
+++ b/src/frontend/app/contexts.js
@@ -1,5 +1,6 @@
 import { createContext } from 'react';
 
+export const AlertContext = createContext();
 export const AuthContext = createContext();
 export const DebuggingContext = createContext(false);
 export const MapContext = createContext();

--- a/src/frontend/app/users/home.scss
+++ b/src/frontend/app/users/home.scss
@@ -74,6 +74,7 @@
       .user-btn {
         font-size: .875rem;
         color: $Grey80;
+        cursor: pointer;
       }
 
       p {

--- a/src/webapp/config/adapter.py
+++ b/src/webapp/config/adapter.py
@@ -3,18 +3,20 @@ from allauth.account.adapter import DefaultAccountAdapter
 from django.contrib.auth.signals import user_logged_in
 from django.conf import settings
 import requests
+from django.http import HttpResponseRedirect
 
 
-class DbcAdapter(DefaultAccountAdapter):
-
+class RideAdapter(DefaultAccountAdapter):
     def get_logout_redirect_url(self, request):
         token = request.session.get('id_token')
         url = f'{settings.KEYCLOAK_URL}/protocol/openid-connect/logout?post_logout_redirect_uri={settings.FRONTEND_BASE_URL}&id_token_hint={token}'
         return url
 
+    def respond_user_inactive(self, request, user):
+        return HttpResponseRedirect(settings.FRONTEND_BASE_URL + '?inactive=true')
 
-class DbcSocialAdapter(DefaultSocialAccountAdapter):
 
+class RideSocialAdapter(DefaultSocialAccountAdapter):
     def populate_user(self, request, sociallogin, data):
         return super().populate_user(request, sociallogin, data)
 

--- a/src/webapp/config/settings/third_party.py
+++ b/src/webapp/config/settings/third_party.py
@@ -24,8 +24,8 @@ SOCIALACCOUNT_STORE_TOKENS = True
 
 # need our own adapter to override various redirect url methods following
 # login or logout
-SOCIALACCOUNT_ADAPTER = 'config.adapter.DbcSocialAdapter'
-ACCOUNT_ADAPTER = 'config.adapter.DbcAdapter'
+SOCIALACCOUNT_ADAPTER = 'config.adapter.RideSocialAdapter'
+ACCOUNT_ADAPTER = 'config.adapter.RideAdapter'
 
 SOCIALACCOUNT_PROVIDERS = {
     'openid_connect': {


### PR DESCRIPTION
[DBC22-4938](https://moti-imb.atlassian.net/browse/DBC22-4938): Disable button implementation + alerts ("toast" in figma) with UNDO. On login, inactive users will be redirected to hostname/?inactive=true which will show an alert "Your account is inactive. Please contact an administrator."

---

Added shared Alert component. Setting AlertContext will display 5s of a given message. e.g. 

```
setAlertContext({
  type: 'success',
  message: `User successfully updated`,
  undoHandler: () => submitForm(true)
});
```

type and undoHandler are optional.