### PR TITLE
DBC22-4895 Pin disappears on moving off road

### DIFF
--- a/src/frontend/app/components/Map/PinLayer.jsx
+++ b/src/frontend/app/components/Map/PinLayer.jsx
@@ -59,7 +59,7 @@ export const endHandler = async (e, point, dispatch) => {
     props?.ROAD_NAME_ALIAS3,
     props?.ROAD_NAME_ALIAS4,
   ].filter(Boolean);
-  let name = props?.ROAD_NAME_FULL;
+  let name = props?.ROAD_NAME_FULL || 'Greenfield';
   if (props?.HIGHWAY_ROUTE_NUMBER) {
     name = `Hwy ${props?.HIGHWAY_ROUTE_NUMBER}`;
     aliases.unshift(props?.ROAD_NAME_FULL);
@@ -73,7 +73,9 @@ export const endHandler = async (e, point, dispatch) => {
       name,
       alias: aliases[0],
       aliases,
-      pending: false, nearbyPending: true
+      nearby: null,
+      pending: false,
+      nearbyPending: true
     }
   });
 
@@ -83,7 +85,7 @@ export const endHandler = async (e, point, dispatch) => {
   }
 
   if (point.dra.properties) {
-    point.nearby = await getNearby(g2ll(point.getGeometry().getCoordinates()));
+    point.nearby = await getNearby(g2ll(point.getGeometry().getCoordinates()), point === e.map.end);
     if (point.nearby[0]) { point.nearby[0].include = true; }
     dispatch({
       type: point.action,
@@ -170,8 +172,9 @@ export default function PinLayer({ event, dispatch }) {
         map.pins.getSource().addFeature(map.start);
       }
     } else if (map.start) { // no start location but start pin exists
-      map.pins.getSource().removeFeature(map.start);
-      map.start = null;
+      // map.pins.getSource().removeFeature(map.start);
+      // console.log('removing');
+      // map.start = null;
     }
 
     if (event.location.end?.name && event.showForm && !event.segment) { // end location but no pin

--- a/src/frontend/app/components/Map/index.jsx
+++ b/src/frontend/app/components/Map/index.jsx
@@ -3,7 +3,7 @@ import { components } from 'react-select';
 import AsyncSelect from 'react-select/async';
 
 
-import { MapContext } from '../../contexts';
+import { DebuggingContext, MapContext } from '../../contexts';
 import { createMap, ll2g } from './helpers';
 import { get } from '../../shared/helpers';
 
@@ -53,6 +53,7 @@ export default function Map({ children, dispatch, event, clickHandler }) {
   eventRef.current = event;
 
   const { map, setMap } = useContext(MapContext);
+  const debuggingIsOn = useContext(DebuggingContext);
   const [ base, setBase ] = useState('vector')
 
   const click = useCallback((e) => {
@@ -83,6 +84,10 @@ export default function Map({ children, dispatch, event, clickHandler }) {
   globalThis.map = map;
 
   const otherBase = base === 'vector' ? 'aerial' : 'vector';
+
+  if (map) {
+    map.get('debug').setVisible(debuggingIsOn);
+  }
 
   return (
     <div ref={elementRef} className="map-container">

--- a/src/frontend/app/components/Map/styles.js
+++ b/src/frontend/app/components/Map/styles.js
@@ -49,8 +49,14 @@ export const dotStyle2 = new Style({
 
 export const lineStyle = new Style({
   stroke: new Stroke({
-    color: [100, 64, 10, 1],
-    width: 4,
+    color: [100, 64, 10, 0.5],
+    width: 5,
+  })
+});
+export const lineStyle2 = new Style({
+  stroke: new Stroke({
+    color: [200, 150, 10, 1],
+    width: 8,
   })
 });
 

--- a/src/frontend/app/events/Location.jsx
+++ b/src/frontend/app/events/Location.jsx
@@ -84,13 +84,13 @@ export default function Location({ errors, event, dispatch, goToFunc }) {
           </div>
         }
 
-        { !start?.nearby && start?.name && <Skeleton width={120} height={20} />}
-        { start?.nearby?.length > 0 &&
           <div>
             <div>
               Reference Location
               &nbsp;<Tooltip text={REF_LOC_TEXT} />
             </div>
+          { !start?.nearby && start?.name && <Skeleton width={250} height={20} />}
+          { start?.nearby?.length > 0 && <>
             { start.nearby.map((loc, ii) => (
               <div key={loc.name}>&nbsp;&nbsp;
                 <input
@@ -125,8 +125,9 @@ export default function Location({ errors, event, dispatch, goToFunc }) {
               />&nbsp;&nbsp;
               <span className={startOther?.length === 100 ? 'bold' : ''}>{startOther?.length}/100</span>
             </div>
-          </div>
+          </>
         }
+        </div>
 
       </div>
     </div>
@@ -181,12 +182,13 @@ export default function Location({ errors, event, dispatch, goToFunc }) {
             </div>
           }
 
-          { end?.nearby?.length > 0 &&
             <div>
               <div>
                 Reference Location
                 &nbsp;<Tooltip text={REF_LOC_TEXT} />
               </div>
+          { !end?.nearby && end?.name && <Skeleton width={250} height={20} />}
+          { end?.nearby?.length > 0 && <>
               { end.nearby.map((loc, ii) => (
                 <div key={loc.name}>&nbsp;&nbsp;
                   <input
@@ -222,8 +224,9 @@ export default function Location({ errors, event, dispatch, goToFunc }) {
                 />&nbsp;&nbsp;
                 <span className={endOther.length === 100 ? 'bold' : ''}>{endOther.length}/100</span>
               </div>
+            </>
+            }
             </div>
-          }
 
         </div>
       </div>

--- a/src/frontend/app/events/Preview.jsx
+++ b/src/frontend/app/events/Preview.jsx
@@ -27,9 +27,9 @@ export default function Preview({ event, dispatch, mapRef, segments }) {
   const start = event.location.start || {};
   const end = event.location.end || {};
   const isLinear = !!end.name;
-  let startNearbies = start.nearby?.filter((loc) => loc.include).map((loc) => loc.phrase);
+  let startNearbies = start.nearby?.filter((loc) => loc.include).map((loc) => loc.phrase) || [];
   if (start.other && start.useOther) { startNearbies.push(start.other); }
-  let endNearbies = (end.nearby || []).filter((loc) => loc.include).map((loc) => loc.phrase);
+  let endNearbies = (end.nearby || []).filter((loc) => loc.include).map((loc) => loc.phrase) || [];
   if (end.other && end.useOther) { endNearbies.push(end.other); }
 
   const lastUpdated = event.last_updated ? new Date(event.last_updated) : new Date(Date.now());

--- a/src/frontend/app/events/forms.css
+++ b/src/frontend/app/events/forms.css
@@ -238,13 +238,13 @@
       }
       .toggleable {
         display: flex;
-        margin-bottom: 0.25rem;
-        &:last-child {
-          margin-bottom: 0;
-        }
+        margin-bottom: 0.5rem;
         .toggle {
           .unfold {
             display: none;
+          }
+          svg {
+            cursor: pointer;
           }
         }
 
@@ -254,15 +254,10 @@
             .unfold { display: inline-block; }
           }
           .toggled {
+            margin-bottom: 0.5rem;
             > div:not(:first-child) {
               display: none;
             }
-          }
-        }
-
-        .toggle {
-          svg {
-            cursor: pointer;
           }
         }
 

--- a/src/frontend/app/events/forms.jsx
+++ b/src/frontend/app/events/forms.jsx
@@ -294,7 +294,7 @@ const LOCATION_BLANK = {
   useAlias: true,
   other: null,
   useOther: false,
-  nearby: [],
+  nearby: null,
 };
 
 const SCHEDULE_BLANK = {


### PR DESCRIPTION
When the pin was moved off a highway, no location name was available, causing the form display to disappear.  This fixes the problem by populating a blank name with "Greenfield", so that event creation continues as normal.

Along the way, added loading indicators to nearby reference locations so that users see a request is pending.

Also added a debug layer to the map, visible only when debugging is enabled, allowing map code to add debug geometry to the map.