### PR TITLE
DBC22-6082: redux crashfix

### DIFF
--- a/src/frontend/app/events/Queue.jsx
+++ b/src/frontend/app/events/Queue.jsx
@@ -1,6 +1,5 @@
 import { useContext, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { createSelector } from '@reduxjs/toolkit'
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faChevronRight } from '@fortawesome/pro-solid-svg-icons';
@@ -13,7 +12,7 @@ import { PHRASES_LOOKUP } from './references';
 import { selectFeature } from '../components/Map/helpers';
 import PollingComponent from '../shared/PollingComponent';
 
-import { refreshPending } from '../slices/pending';
+import { refreshPending, selectAllPending } from '../slices/pending';
 
 import './Queue.scss';
 
@@ -86,15 +85,9 @@ function Pending({ event, dispatch, goToFunc, map }) {
   );
 }
 
-const selectPending = (state) => state.pending;
-const selectMemoizedPending = createSelector(
-  [selectPending],
-  (pending) => pending.ids.map((id) => pending.entities[id]),
-);
-
 export default function Queue({ dispatch, goToFunc, map }) {
   const storeDispatch = useDispatch()
-  const pending = useSelector(selectMemoizedPending);
+  const pending = useSelector(selectAllPending);
 
   return (
     <div className='queue'>

--- a/src/frontend/app/slices/pending.js
+++ b/src/frontend/app/slices/pending.js
@@ -22,8 +22,21 @@ const refreshThunk = createAsyncThunk(
   }
 );
 
-const selectStatus = (state) => state.pending.status;
-const selectLength = (state) => state.pending.ids.length;
+const selectStatus = (state) => state.pending?.status ?? 'idle';
+
+/** Entity state can lose `ids` if setAll ever receives a non-array payload; keep selectors safe. */
+function selectPendingRoot(state) {
+  const s = state.pending;
+  if (s && Array.isArray(s.ids) && typeof s.entities === 'object') {
+    return s;
+  }
+  return pendingAdapter.getInitialState({
+    status: s?.status ?? 'idle',
+    error: s?.error ?? null,
+  });
+}
+
+const selectLength = (state) => selectPendingRoot(state).ids.length;
 
 export const slice = createSlice({
   name: 'pending',
@@ -42,7 +55,8 @@ export const slice = createSlice({
       })
       .addCase(refreshThunk.fulfilled, (state, action) => {
         state.status = 'idle';
-        pendingAdapter.setAll(state, action.payload);
+        const list = Array.isArray(action.payload) ? action.payload : [];
+        pendingAdapter.setAll(state, list);
       })
       .addCase(refreshThunk.rejected, (state, action) => {
         state.status = 'failed';
@@ -55,7 +69,7 @@ export const {
   selectAll: selectAllPending,
   selectById: selectPendingById,
   selectIds: selectPendingIds,
-} = pendingAdapter.getSelectors((state) => state.pending)
+} = pendingAdapter.getSelectors(selectPendingRoot)
 export {
   refreshThunk as refreshPending,
   selectStatus as selectPendingStatus,


### PR DESCRIPTION
[DBC22-6082](https://moti-imb.atlassian.net/browse/DBC22-6082)

This is likely where the crash occured:

`const selectPending = (state) => state.pending;
const selectMemoizedPending = createSelector(
  [selectPending],
  (pending) => pending.ids.map((id) => pending.entities[id]),
);`

AI Output to be reviewed:

**Problem**
The Awaiting approval queue used a selector that did pending.ids.map(...). The pending slice is an entity adapter state (ids + entities). If that shape was ever wrong—especially if ids was not a valid array—that .map threw.

**Changes**
- pending.js
1. On refresh/fulfilled, only call setAll with Array.isArray(action.payload) ? action.payload : [], so we never pass a non-array into the adapter.
2. Add selectPendingRoot so selectors only see valid entity state (or a safe empty fallback)
3. Use it for getSelectors, and use it (or optional chaining) for selectLength / selectStatus.

- Queue.jsx
1. Remove the hand-written createSelector that duplicated selectAll.
2. Use selectAllPending from the slice instead, which is the standard entity selectAll and benefits from the safer root selector.