### PR TITLE
DBC22-5896 Some events not showing history

### DIFF
--- a/src/webapp/apps/events/serializers.py
+++ b/src/webapp/apps/events/serializers.py
@@ -6,7 +6,6 @@ from django.contrib.gis.geos import Point
 
 from rest_framework import fields, serializers
 from rest_framework.serializers import ModelSerializer
-from rest_framework_gis.fields import GeometryField
 
 from config.settings import EVENT_PREFIX
 from .models import Event, Note, TrafficImpact, Condition
@@ -47,7 +46,6 @@ class NotesListSerializer(fields.ListField):
 
 
 class EventSerializer(KeyMoveSerializer):
-    geometry = GeometryField()
     is_closure = fields.SerializerMethodField()
     last_inactivated = fields.SerializerMethodField()
     ongoing = fields.SerializerMethodField()

--- a/src/webapp/apps/shared/models.py
+++ b/src/webapp/apps/shared/models.py
@@ -1,3 +1,4 @@
+import json
 import uuid
 
 from dictdiffer import diff
@@ -27,8 +28,14 @@ class LocationField(models.JSONField):
         return models.JSONField().db_type(connection)
 
     def diff(self, a, b):
-
         result = {}
+
+        if a is None and b is not None:
+            result['location'] = { 'add': b.get('name') }
+            return result  # further diffing not possible
+        elif a is not None and b is None:
+            result['location'] = { 'remove': a.get('name') }
+            return result  # further diffing not possible
 
         coords_a = a.get('coords')
         coords_b = b.get('coords')
@@ -223,15 +230,16 @@ class VersionedModel(models.Model):
             for field in self._meta.get_fields():
                 if field.name in self.get_ignored_fields():
                     continue
-
                 current = getattr(self, field.name)
                 previous = getattr(prior, field.name)
 
                 if current != previous:
-                    if field.get_internal_type() in ['LocationField', 'OrderedListField']:
+                    if hasattr(field, 'diff'):
                         changes[field.name] = field.diff(previous, current)
                     elif field.get_internal_type() == 'JSONField':
                         changes[field.name] = diff(previous, current)
+                    elif field.get_internal_type() == 'GeometryCollectionField':
+                        changes[field.name] = json.loads(previous.geojson)
                     else:
                         changes[field.name] = previous
 

--- a/src/webapp/apps/shared/serializers.py
+++ b/src/webapp/apps/shared/serializers.py
@@ -11,6 +11,7 @@ class UserSerializer(ModelSerializer):
         model = get_user_model()
         fields = ['id', 'first_name', 'last_name', 'email', 'username']
 
+
 class VersionSerializer(ModelSerializer):
 
     user = UserSerializer(default=serializers.CurrentUserDefault())


### PR DESCRIPTION
Fixes issue with event history not showing, caused by API call returning 500 status, caused by diff'ing some events failing on geometry changes.  Fixes geometry diffing.