### PR TITLE
DBC22-5643 Future events not obeying map layer visibility

### DIFF
--- a/src/frontend/app/components/Map/helpers.js
+++ b/src/frontend/app/components/Map/helpers.js
@@ -214,7 +214,6 @@ export function createMap() {
     classname: 'debug',
     visible: true,
     source: new VectorSource({ format: new GeoJSON() }),
-    // style: null,
     style: layerStyle,
     renderBuffer: 30,
     zIndex: 300,
@@ -236,7 +235,6 @@ export function createMap() {
     moveTolerance: 7,
     controls: [new ScaleLine({ units: 'metric' })],
   });
-
 
   map.set('base', 'vector')
   map.set('vector', vectorLayer);
@@ -377,10 +375,6 @@ export const ll2bc = (coords) => proj4('EPSG:4326', 'EPSG:3005', coords);
 export const bc2g = (coords) => proj4('EPSG:3005', 'EPSG:3857', coords);
 export const g2bc = (coords) => proj4('EPSG:3857', 'EPSG:3005', coords);
 
-function eq(a, b) {
-  return a[0] === b[0] && a[1] === b[1];
-}
-
 // roads not considered for snapping
 const EXCLUDED_CLASSES = [
   'alleyway',
@@ -460,7 +454,9 @@ export function getDRA(coords, point, map) {
              */
             if (ex.message === 'coordinates must contain numbers') {
               line = turf.lineString(
-                feat.geometry.coordinates.filter((cc, i, list) => i < 1 || !eq(cc, list[i - 1]))
+                feat.geometry.coordinates.filter(
+                  (cc, i, list) => i < 1 || !coordsMatch(cc, list[i - 1])
+                )
               );
               snapped = turf.nearestPointOnLine(line, point2, { units: "meters" });
             }
@@ -554,9 +550,8 @@ export async function getNearby(coords, reverseRouteOrder) {
     return results.map((result) => ({... result, source: 'bcgnws', displayDistance: Math.round(result.distance)})).slice(0, 6);
   } catch (err) {
     console.error(err);
-    return [{ source: 'bcgnws', name: 'error', phrase: 'Problem retrieving population centres data. Refresh to try again.' }];
+    return [{ source: 'bcgnws', name: 'error', phrase: 'Problem retrieving population centres data.' }];
   }
-
 }
 
 export const convertToDateTimeLocalString = (date) => {
@@ -623,6 +618,7 @@ function getLine(coords, name) {
   return f;
 }
 
+
 /* Finds the nearest road segment on the underlying vector tile to the
  * coordinate, then finds the nearest point on that segment and returns that
  * point.
@@ -634,20 +630,24 @@ export function getSnapped(coordinate, pixel, map) {
   map.get('debug').getSource().remove(name);
 
   map.getFeaturesAtPixel(pixel, { hitTolerance: 50 })
-    .filter((f) => f.get('mvt:layer')?.startsWith('DRA Roads'))
-    .map((f) => {
-      const lines = multi(f.getFlatCoordinates(), f.getEnds().map(a => a), g2ll)
+    .filter((feature) => feature.get('mvt:layer')?.startsWith('DRA Roads'))
+    .map((feature) => {
+      const lines = multi(
+        feature.getFlatCoordinates(),
+        feature.getEnds().map(a => a),
+        g2ll
+      );
       const line = turf.multiLineString(lines);
-      f.debugLine = getLine(lines, name);
+      feature.debugLine = getLine(lines, name);
       // map.get('debug').getSource().addFeature(f.debugLine);
-      f.snapped = turf.nearestPointOnLine(line, point, { units: "meters" });
-      f.closest = !closest || f.snapped.properties.dist < closest.dist;
-      if (f.closest) {
+      feature.snapped = turf.nearestPointOnLine(line, point, { units: "meters" });
+      feature.closest = !closest || feature.snapped.properties.dist < closest.dist;
+      if (feature.closest) {
         if (closest) { closest.closest = false; }
-        closest = f;
+        closest = feature;
       }
-      f.dist = f.snapped.properties.dist;
-      return f;
+      feature.dist = feature.snapped.properties.dist;
+      return feature;
     });
 
   if (closest) {

--- a/src/frontend/app/events/EventCardLocation.jsx
+++ b/src/frontend/app/events/EventCardLocation.jsx
@@ -44,8 +44,6 @@ export function EventCardLocation({ event }) {
   );
   const { startNearby, endNearby } = eventCardNearbyStrings(event);
 
-  console.log(event);
-
   return (
     <div className='event-card-place'>
       <div className='location'>

--- a/src/frontend/app/events/icons/index.js
+++ b/src/frontend/app/events/icons/index.js
@@ -805,10 +805,11 @@ export function getIconAndStroke(event, state='static', includePending=true) {
         }
       }
 
-      tense = type === 'incident' ? 'present' : 'future';
+      const start = new Date(event.timing.startTime);
+      tense = (type === 'incident' || Date.now() >= start) ? 'present' : 'future';
       closure = event.is_closure ? 'closure' : 'open';
 
-// incident minor present closure pending static
+      // incident minor present closure pending static
       return [
         icons[type][severity][tense][closure][status][state],
         strokes[severity][status][state],


### PR DESCRIPTION
Fixes longstanding issue where planned events were always being given the future icon, without checking if they'd started.

Includes some automated refactoring in helpers.js and removing a console.log statement in eventcardlocation.jsx.