### PR TITLE
DBC22-6446 Cleared event not disappearing

### DIFF
--- a/src/frontend/app/components/Map/feature.js
+++ b/src/frontend/app/components/Map/feature.js
@@ -32,13 +32,18 @@ export default class RideFeature extends Feature {
   // used to update available styles based on the underlying event changing
   propertyChanged(e) {
     if (e.key === 'raw') {
-      const event = this.get('raw');
-      ['static', 'hover', 'active'].forEach((state) => {
-        const [icon, stroke2] = getIconAndStroke(event, state);
-        this[state] = new Style({ image: new Icon({ src: icon }), ...stroke2 });
-      });
+      this.updateStyles();
       this.changed();
     }
+  }
+
+  updateStyles() {
+    const event = this.get('raw');
+    ['static', 'hover', 'active'].forEach((state) => {
+      const [icon, stroke2] = getIconAndStroke(event, state);
+      if (state === 'static') { state = 'normal'; }
+      this[state] = new Style({ image: new Icon({ src: icon }), ...stroke2 });
+    });
   }
 
   clear() { // used by the route feature on the map

--- a/src/frontend/app/components/Map/layers/Events.jsx
+++ b/src/frontend/app/components/Map/layers/Events.jsx
@@ -111,7 +111,8 @@ function getVisibility(event, visibleLayers) {
   const typeLayer = typeLayerMap[normalizedType];
   if (typeLayer) {
     // DBC22-6330: Inactive rcs should not show in map
-    if (typeLayer === 'roadConditions' && event.status === 'Inactive') {
+    // DBC22-6446: Inactive chainups also hidden
+    if (['chainups', 'roadConditions'].includes(typeLayer) && event.status === 'Inactive') {
       return false;
     }
 

--- a/src/frontend/app/components/Map/layers/Events.jsx
+++ b/src/frontend/app/components/Map/layers/Events.jsx
@@ -20,7 +20,7 @@ import RideFeature, { PinFeature } from '../feature.js';
 import ContextMenu from '../../../events/ContextMenu.jsx';
 import { getInitialEvent } from '../../../events/forms/index.jsx';
 
-import { API_HOST, EVENT_POLLING_REFRESH } from '../../../env.js';
+import { API_HOST, CLEARING_TIMEOUT, EVENT_POLLING_REFRESH } from '../../../env.js';
 import { getIconAndStroke } from '../../../events/icons/index.js';
 import { getPendingNextUpdate } from '../../../shared/helpers.js';
 import { applyPinLocationUpdate } from './Pins';
@@ -101,7 +101,7 @@ export function addEvent(event, map, dispatch, visibleLayers) {
 function getVisibility(event, visibleLayers) {
   const now = new Date()
   const SEVEN_DAYS_AGO = now - 1000 * 60 * 60 * 24 * 7;
-  const FIFTEEN_MINUTES_AGO = now - 1000 * 60 * 15;
+  const FIFTEEN_MINUTES_AGO = now - CLEARING_TIMEOUT;
 
   const normalizedType = (event.type || '').toLowerCase().replaceAll(/\s|_|-/g, '');
   const typeLayerMap = {
@@ -456,6 +456,12 @@ export default function EventsLayer({ event, dispatch }) {
         type: 'success',
         message: updatedEvent.approved ? 'Event cleared' : 'Event clearing requested',
       });
+      setTimeout(() => {
+        const feature = map.get('events').getSource().get(id);
+        feature.set('visible', getVisibility(updatedEvent, visibleLayers));
+        feature.updateStyles();
+        feature.changed();
+      }, CLEARING_TIMEOUT + 1000);
 
     }).catch((error) => {
       setAlertContext?.({ message: error.message });

--- a/src/frontend/app/env.js
+++ b/src/frontend/app/env.js
@@ -14,6 +14,7 @@ export const RELEASE = `${getEnv('RELEASE')}`;
 export const ALLOW_LOCAL_ACCOUNTS = `${getEnv('ALLOW_LOCAL_ACCOUNTS')}`;
 export const EVENT_POLLING_REFRESH = `${getEnv('EVENT_POLLING_REFRESH')}`;
 export const DMS_API_URL = `${getEnv('DMS_API_URL')}`;
+export const CLEARING_TIMEOUT = parseInt(`${getEnv('CLEARING_TIMEOUT', 900000)}`);
 // set to true to remove geometries from service areas so that data is small
 // enough for redux-devtools to work with the store
 export const ELIDE_SERVICE_AREA_GEOMETRIES = `${getEnv('ELIDE_SERVICE_AREA_GEOMETRIES')}`;

--- a/src/frontend/app/events/icons/index.js
+++ b/src/frontend/app/events/icons/index.js
@@ -1,4 +1,6 @@
-import { Fill, Stroke, Style } from 'ol/style.js';
+import { Fill, Stroke } from 'ol/style.js';
+
+import { CLEARING_TIMEOUT } from '../../env';
 
 import incidentMajorActiveStatic from './majorincident-default-static.svg';
 import incidentMajorActiveHover from './majorincident-default-hover.svg';
@@ -156,18 +158,6 @@ import {
   faMountain,
   faWater
 } from '@fortawesome/pro-regular-svg-icons';
-
-import chainup from './chainup.svg';
-import closure from './closure.svg';
-import majordelay from './majordelay.svg';
-import majorfuture from './majorfuture.svg';
-import majorfutureclosure from './majorfutureclosure.svg';
-import majorincident from './majorincident.svg';
-import minordelay from './minordelay.svg';
-import minorfuture from './minorfuture.svg';
-import minorfutureclosure from './minorfutureclosure.svg';
-import MinorIncident from './minorincident.svg?react';
-import roadcondition from './roadcondition.svg';
 
 import './icons.scss';
 
@@ -800,7 +790,7 @@ export function getIconAndStroke(event, state='static', includePending=true) {
 
       if (status === 'inactive') { // TODO: cleared determine by time of last inactivation
         const lastUpdated = new Date(event.last_updated);
-        if (!event.approved || lastUpdated > Date.now() - 60000 * 15) {  // TODO: time window move to env variable
+        if (!event.approved || lastUpdated > Date.now() - CLEARING_TIMEOUT) {
           status = 'clearing';
         }
       }

--- a/src/frontend/app/root.jsx
+++ b/src/frontend/app/root.jsx
@@ -1,4 +1,4 @@
-import { createContext, useState } from 'react';
+import { useState } from 'react';
 import {
   isRouteErrorResponse,
   Links,
@@ -28,19 +28,6 @@ import {
 } from './slices';
 
 import "./app.scss";
-
-export const links = () => [
-  { rel: "preconnect", href: "https://fonts.googleapis.com" },
-  {
-    rel: "preconnect",
-    href: "https://fonts.gstatic.com",
-    crossOrigin: "anonymous",
-  },
-  {
-    rel: "stylesheet",
-    href: "https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap",
-  },
-];
 
 export function Layout({ children }) {
   return (


### PR DESCRIPTION
Fixes problem with events transitioning from a recently cleared (i.e., green) state to a cleared (i.e., grey) state after the 15 minute window.  If the cleared layer is visible, the icon should change colours; if the layer is not visible, the cleared icon should disappear.

Introduces an optional env variable, CLEARING_TIMEOUT, that defaults to 900,000, or 15 minutes.