### PR TITLE
DBC22-6995: Update INCR backups to be block based

### DIFF
--- a/infrastructure/crunchy-postgres/templates/PostgresCluster.yaml
+++ b/infrastructure/crunchy-postgres/templates/PostgresCluster.yaml
@@ -162,11 +162,15 @@ spec:
       global:
         repo1-retention-full: {{ .Values.crunchy.pgBackRest.pvc.retention | quote }}
         repo1-retention-full-type: {{ .Values.crunchy.pgBackRest.pvc.retentionFullType }}
+        repo1-bundle: "y"
+        repo1-block: "y"
         {{- if .Values.crunchy.pgBackRest.s3.enabled }}
         repo2-retention-full: {{ .Values.crunchy.pgBackRest.s3.retention | quote }}
         repo2-retention-full-type: {{ .Values.crunchy.pgBackRest.retentionFullType }}
         repo2-path: '{{ .Values.crunchy.pgBackRest.backupPath }}/{{ .Values.crunchy.pgBackRest.clusterCounter }}'
         repo2-s3-uri-style: path
+        repo2-bundle: "y"
+        repo2-block: "y"
         {{- end }}
       repos:
         - name: repo1


### PR DESCRIPTION
To reduce size of incremental backups, using block based backups and bundles will improve efficiency and speed.